### PR TITLE
Add unit tests for API and updater modules

### DIFF
--- a/apps/api/src/lib/__tests__/getCarsByFuelType.test.ts
+++ b/apps/api/src/lib/__tests__/getCarsByFuelType.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getCarsByFuelType } from "../getCarsByFuelType";
+import db from "@api/config/db";
+import { getLatestMonth } from "../getLatestMonth";
+import { getTrailingTwelveMonths } from "@sgcarstrends/utils";
+import { and, asc, between, desc, eq, ilike, or } from "drizzle-orm";
+import { cars } from "@sgcarstrends/schema";
+
+// Mock the cars schema
+vi.mock("@sgcarstrends/schema", () => ({
+  cars: {
+    month: "month",
+    make: "make",
+    fuel_type: "fuel_type",
+  }
+}));
+
+// Mock drizzle-orm
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  asc: vi.fn(),
+  between: vi.fn(),
+  desc: vi.fn(),
+  eq: vi.fn(),
+  ilike: vi.fn(),
+  or: vi.fn(),
+}));
+
+vi.mock("@api/config/db", () => ({
+  default: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("../getLatestMonth", () => ({
+  getLatestMonth: vi.fn(),
+}));
+
+vi.mock("@sgcarstrends/utils", () => ({
+  getTrailingTwelveMonths: vi.fn(),
+}));
+
+describe("getCarsByFuelType", () => {
+  const mockLatestMonth = "2023-12";
+  const mockTrailingMonth = "2023-01";
+  
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getLatestMonth).mockResolvedValue(mockLatestMonth);
+    vi.mocked(getTrailingTwelveMonths).mockReturnValue(mockTrailingMonth);
+    
+    // Setup db chain mocks
+    const mockWhere = vi.fn().mockReturnValue({
+      orderBy: vi.fn(),
+    });
+    
+    const mockFrom = vi.fn().mockReturnValue({
+      where: mockWhere,
+    });
+    
+    vi.mocked(db.select).mockReturnValue({
+      from: mockFrom,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should fetch cars by fuel type for specified month", async () => {
+    const mockFuelType = "Electric";
+    const mockMonth = "2023-10";
+    const mockResults = [
+      { month: mockMonth, make: "Tesla", number: "100", fuel_type: "Electric" },
+      { month: mockMonth, make: "Nissan", number: "50", fuel_type: "Electric" },
+    ];
+    
+    // Setup the orderBy to return our mock results
+    vi.mocked(db.select().from().where().orderBy).mockResolvedValue(mockResults);
+    
+    const result = await getCarsByFuelType(mockFuelType, mockMonth);
+    
+    expect(getLatestMonth).toHaveBeenCalled();
+    expect(db.select).toHaveBeenCalled();
+    expect(db.select().from).toHaveBeenCalled();
+    expect(db.select().from().where).toHaveBeenCalled();
+    expect(db.select().from().where().orderBy).toHaveBeenCalled();
+    
+    expect(result).toHaveLength(2);
+    expect(result[0].number).toBe(100);
+    expect(result[1].number).toBe(50);
+  });
+
+  it("should fetch cars by fuel type for trailing 12 months when month not specified", async () => {
+    const mockFuelType = "Electric";
+    const mockResults = [
+      { month: "2023-12", make: "Tesla", number: "100", fuel_type: "Electric" },
+      { month: "2023-11", make: "Tesla", number: "90", fuel_type: "Electric" },
+    ];
+    
+    // Setup the orderBy to return our mock results
+    vi.mocked(db.select().from().where().orderBy).mockResolvedValue(mockResults);
+    
+    const result = await getCarsByFuelType(mockFuelType);
+    
+    expect(getLatestMonth).toHaveBeenCalled();
+    expect(getTrailingTwelveMonths).toHaveBeenCalledWith(mockLatestMonth);
+    expect(db.select).toHaveBeenCalled();
+    expect(db.select().from).toHaveBeenCalled();
+    expect(db.select().from().where).toHaveBeenCalled();
+    expect(db.select().from().where().orderBy).toHaveBeenCalled();
+    
+    expect(result).toHaveLength(2);
+  });
+
+  it("should aggregate results by month and make", async () => {
+    const mockFuelType = "Electric";
+    const mockResults = [
+      { month: "2023-12", make: "Tesla", number: "50", fuel_type: "Electric" },
+      { month: "2023-12", make: "Tesla", number: "50", fuel_type: "Electric" },
+      { month: "2023-12", make: "Nissan", number: "30", fuel_type: "Electric" },
+    ];
+    
+    // Setup the orderBy to return our mock results
+    vi.mocked(db.select().from().where().orderBy).mockResolvedValue(mockResults);
+    
+    const result = await getCarsByFuelType(mockFuelType);
+    
+    expect(result).toHaveLength(2);
+    
+    const teslaResult = result.find((car) => car.make === "Tesla");
+    expect(teslaResult).toBeDefined();
+    expect(teslaResult?.number).toBe(100);
+    
+    const nissanResult = result.find((car) => car.make === "Nissan");
+    expect(nissanResult).toBeDefined();
+    expect(nissanResult?.number).toBe(30);
+  });
+
+  it("should handle hybrid fuel types correctly", async () => {
+    const mockFuelType = "Hybrid";
+    const mockResults = [];
+    
+    // Setup the orderBy to return our mock results
+    vi.mocked(db.select().from().where().orderBy).mockResolvedValue(mockResults);
+    
+    await getCarsByFuelType(mockFuelType);
+    
+    // We can't easily test the SQL filter, but we can verify the function was called 
+    expect(or).toHaveBeenCalled();
+  });
+
+  it("should handle errors properly", async () => {
+    const mockFuelType = "Electric";
+    const mockError = new Error("Database error");
+    
+    // Setup the orderBy to throw our mock error
+    vi.mocked(db.select().from().where().orderBy).mockRejectedValue(mockError);
+    
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    await expect(getCarsByFuelType(mockFuelType)).rejects.toThrow(mockError);
+    
+    expect(consoleSpy).toHaveBeenCalledWith(mockError);
+    
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/api/src/lib/__tests__/getLatestMonth.test.ts
+++ b/apps/api/src/lib/__tests__/getLatestMonth.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLatestMonth } from "../getLatestMonth";
+import db from "@api/config/db";
+
+vi.mock("@api/config/db", () => ({
+  default: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+  },
+}));
+
+describe("getLatestMonth", () => {
+  const mockTable = { month: "month" } as any;
+  
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return the latest month from the table", async () => {
+    const mockMonth = "2023-12";
+    
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockResolvedValue([{ month: mockMonth }]),
+    } as any);
+
+    const result = await getLatestMonth(mockTable);
+    
+    expect(db.select).toHaveBeenCalled();
+    expect(result).toBe(mockMonth);
+  });
+
+  it("should return null when no data is found", async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockResolvedValue([{ month: null }]),
+    } as any);
+    
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    
+    const result = await getLatestMonth(mockTable);
+    
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(result).toBeNull();
+    
+    consoleSpy.mockRestore();
+  });
+
+  it("should handle errors properly", async () => {
+    const mockError = new Error("Database error");
+    
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockRejectedValue(mockError),
+    } as any);
+    
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    await expect(getLatestMonth(mockTable)).rejects.toThrow(mockError);
+    
+    expect(consoleSpy).toHaveBeenCalledWith(mockError);
+    
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/api/src/lib/__tests__/getUniqueMonths.test.ts
+++ b/apps/api/src/lib/__tests__/getUniqueMonths.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getUniqueMonths } from "../getUniqueMonths";
+import db from "@api/config/db";
+import redis from "@api/config/redis";
+import { getTableName } from "drizzle-orm";
+
+vi.mock("@api/config/db", () => ({
+  default: {
+    selectDistinct: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock("@api/config/redis", () => ({
+  default: {
+    smembers: vi.fn(),
+    sadd: vi.fn().mockResolvedValue(true),
+    expire: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  desc: vi.fn(),
+  getTableName: vi.fn(),
+}));
+
+describe("getUniqueMonths", () => {
+  const mockTable = { month: "month" } as any;
+  const mockTableName = "test_table";
+  
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getTableName).mockReturnValue(mockTableName);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return cached months if available", async () => {
+    const cachedMonths = ["2023-12", "2023-11", "2023-10"];
+    vi.mocked(redis.smembers).mockResolvedValue(cachedMonths);
+    
+    const result = await getUniqueMonths(mockTable);
+    
+    expect(redis.smembers).toHaveBeenCalledWith(`${mockTableName}:months`);
+    expect(db.selectDistinct).not.toHaveBeenCalled();
+    expect(result).toEqual(cachedMonths);
+  });
+
+  it("should fetch months from database when cache is empty", async () => {
+    const dbMonths = [
+      { month: "2023-12" },
+      { month: "2023-11" },
+      { month: "2023-10" },
+    ];
+    const expectedMonths = ["2023-12", "2023-11", "2023-10"];
+    
+    vi.mocked(redis.smembers).mockResolvedValue([]);
+    vi.mocked(db.selectDistinct).mockReturnValue({
+      from: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue(dbMonths),
+    } as any);
+    
+    const result = await getUniqueMonths(mockTable);
+    
+    expect(redis.smembers).toHaveBeenCalledWith(`${mockTableName}:months`);
+    expect(db.selectDistinct).toHaveBeenCalled();
+    expect(redis.sadd).toHaveBeenCalledWith(`${mockTableName}:months`, expectedMonths);
+    expect(redis.expire).toHaveBeenCalled();
+    expect(result).toEqual(expectedMonths);
+  });
+
+  it("should handle custom key parameter", async () => {
+    const customKey = "custom_month";
+    const customTable = { [customKey]: customKey } as any;
+    
+    vi.mocked(redis.smembers).mockResolvedValue([]);
+    vi.mocked(db.selectDistinct).mockReturnValue({
+      from: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue([]),
+    } as any);
+    
+    await getUniqueMonths(customTable, customKey);
+    
+    expect(db.selectDistinct).toHaveBeenCalled();
+  });
+
+  it("should handle errors properly", async () => {
+    const mockError = new Error("Redis error");
+    
+    vi.mocked(redis.smembers).mockRejectedValue(mockError);
+    
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    
+    await expect(getUniqueMonths(mockTable)).rejects.toThrow(mockError);
+    
+    expect(consoleSpy).toHaveBeenCalledWith(mockError);
+    
+    consoleSpy.mockRestore();
+  });
+
+  it("should sort months in descending order", async () => {
+    const unsortedMonths = ["2023-10", "2023-12", "2023-11"];
+    const expectedSortedMonths = ["2023-12", "2023-11", "2023-10"];
+    
+    vi.mocked(redis.smembers).mockResolvedValue(unsortedMonths);
+    
+    const result = await getUniqueMonths(mockTable);
+    
+    expect(result).toEqual(expectedSortedMonths);
+  });
+});

--- a/apps/updater/src/utils/__tests__/createUpdateTask.test.ts
+++ b/apps/updater/src/utils/__tests__/createUpdateTask.test.ts
@@ -1,0 +1,133 @@
+// Mock required modules before imports
+import { vi } from "vitest";
+
+// Mock Redis module to avoid SST Resource issues
+vi.mock("@updater/config/redis", () => ({
+  default: {
+    set: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+// Mock trigger.dev SDK
+vi.mock("@trigger.dev/sdk/v3", () => ({
+  AbortTaskRunError: class AbortTaskRunError extends Error {
+    constructor(error) {
+      super(error.message);
+      this.name = "AbortTaskRunError";
+    }
+  },
+  logger: {
+    log: vi.fn(),
+    error: vi.fn(),
+  },
+  schedules: {
+    task: vi.fn(),
+  },
+}));
+
+// Now import the modules
+import { createUpdateTask } from "@updater/utils/createUpdateTask";
+import { AbortTaskRunError, logger, schedules } from "@trigger.dev/sdk/v3";
+import redis from "@updater/config/redis";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("createUpdateTask", () => {
+  const mockSchedulerName = "test-updater";
+  const mockCron = { cron: "0 0 * * *" };
+  
+  let mockUpdaterFn;
+  let taskConfig;
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Mock updater function
+    mockUpdaterFn = vi.fn().mockResolvedValue({
+      recordsProcessed: 10,
+      message: "Update successful",
+      timestamp: new Date().toISOString(),
+    });
+    
+    // Setup the task mock to capture config and return a mock task
+    vi.mocked(schedules.task).mockImplementation((config) => {
+      taskConfig = config;
+      return { id: config.id };
+    });
+  });
+  
+  it("should create a scheduled task with the correct configuration", () => {
+    const result = createUpdateTask(mockSchedulerName, mockCron, mockUpdaterFn);
+    
+    expect(schedules.task).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: mockSchedulerName,
+        cron: mockCron,
+      })
+    );
+    
+    expect(result).toBeDefined();
+  });
+  
+  it("should call the updater function when the task runs", async () => {
+    createUpdateTask(mockSchedulerName, mockCron, mockUpdaterFn);
+    
+    // Execute the run function
+    await taskConfig.run({}, { ctx: {} });
+    
+    expect(mockUpdaterFn).toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      "Starting updater task",
+      expect.any(Object)
+    );
+  });
+  
+  it("should update the last updated time on success", async () => {
+    createUpdateTask(mockSchedulerName, mockCron, mockUpdaterFn);
+    
+    // Execute the onSuccess function
+    await taskConfig.onSuccess();
+    
+    expect(redis.set).toHaveBeenCalledWith(
+      `lastUpdated:${mockSchedulerName.toLowerCase()}`,
+      expect.any(Number)
+    );
+    
+    expect(logger.log).toHaveBeenCalledWith(
+      "Last updated",
+      expect.objectContaining({ timestamp: expect.any(Number) })
+    );
+  });
+  
+  it("should handle errors during task execution", async () => {
+    const mockError = new Error("Updater failed");
+    mockUpdaterFn.mockRejectedValue(mockError);
+    
+    createUpdateTask(mockSchedulerName, mockCron, mockUpdaterFn);
+    
+    try {
+      await taskConfig.run({}, { ctx: {} });
+      // If it doesn't throw, we should fail the test
+      expect(true).toBe(false);
+    } catch (error) {
+      expect(error.name).toBe("AbortTaskRunError");
+      expect(logger.error).toHaveBeenCalledWith(
+        "Update task failed",
+        expect.objectContaining({ error: mockError })
+      );
+    }
+  });
+  
+  it("should handle task permanent failure", async () => {
+    createUpdateTask(mockSchedulerName, mockCron, mockUpdaterFn);
+    
+    const mockError = new Error("Task failed permanently");
+    
+    // Execute the onFailure function
+    await taskConfig.onFailure({}, mockError, { ctx: {} });
+    
+    expect(logger.error).toHaveBeenCalledWith(
+      "Update Task Permanent Failure",
+      expect.objectContaining({ error: mockError })
+    );
+  });
+});

--- a/apps/updater/src/utils/__tests__/downloadFile.test.ts
+++ b/apps/updater/src/utils/__tests__/downloadFile.test.ts
@@ -1,0 +1,93 @@
+import { AWS_LAMBDA_TEMP_DIR } from "@updater/config";
+import { downloadFile } from "@updater/utils/downloadFile";
+import AdmZip from "adm-zip";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@updater/config", () => ({
+  AWS_LAMBDA_TEMP_DIR: "/tmp",
+}));
+
+// Mock fetch
+global.fetch = vi.fn();
+
+// Mock AdmZip
+vi.mock("adm-zip", () => {
+  const mockEntries = [
+    { 
+      isDirectory: false, 
+      entryName: "test.csv",
+    },
+    { 
+      isDirectory: false, 
+      entryName: "data.csv",
+    },
+    { 
+      isDirectory: true, 
+      entryName: "folder/",
+    },
+  ];
+  
+  return {
+    default: class MockAdmZip {
+      constructor() {}
+      
+      getEntries() {
+        return mockEntries;
+      }
+      
+      extractEntryTo(entry, path, maintainEntryPath, overwrite) {
+        return true;
+      }
+    }
+  };
+});
+
+describe("downloadFile", () => {
+  const mockUrl = "https://example.com/test.zip";
+  
+  beforeEach(() => {
+    vi.resetAllMocks();
+    
+    // Mock successful fetch response
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+    } as unknown as Response);
+  });
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+  
+  it("should fetch and extract files from a zip", async () => {
+    const result = await downloadFile(mockUrl);
+    
+    expect(global.fetch).toHaveBeenCalledWith(mockUrl);
+    expect(result).toBe("test.csv"); // Should return first file
+  });
+  
+  it("should return the specific file when csvFile parameter is provided", async () => {
+    const result = await downloadFile(mockUrl, "data");
+    
+    expect(global.fetch).toHaveBeenCalledWith(mockUrl);
+    expect(result).toBe("data.csv");
+  });
+  
+  it("should handle HTTP errors", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as unknown as Response);
+    
+    await expect(downloadFile(mockUrl)).rejects.toThrow("HTTP error! status: 404");
+  });
+  
+  it("should handle fetch failures", async () => {
+    const mockError = new Error("Network error");
+    vi.mocked(global.fetch).mockRejectedValue(mockError);
+    
+    await expect(downloadFile(mockUrl)).rejects.toThrow(mockError);
+  });
+});

--- a/apps/updater/src/utils/__tests__/processCSV.test.ts
+++ b/apps/updater/src/utils/__tests__/processCSV.test.ts
@@ -1,5 +1,7 @@
-import { processCSV } from "@updater/utils/processCSV";
 import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { processCSV } from "@updater/utils/processCSV";
 import Papa from "papaparse";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -14,33 +16,42 @@ interface TestRecord {
 }
 
 describe("processCSV", () => {
-  const filePath = "/tmp/test.csv";
-  
+  // Temporary path for testing
+  const tmpDirectory = os.tmpdir();
+  const filePath = path.join(tmpDirectory, "test.csv");
+
   beforeEach(() => {
     vi.clearAllMocks();
-    
+
     // Set up mock implementations for each test
     vi.mocked(fs.readFileSync).mockReturnValue("mock csv content" as any);
-    
+
     vi.mocked(Papa.parse).mockReturnValue({
       data: [
         { name: " John Doe ", age: "25", active: "true" },
         { name: " Jane Smith ", age: "30", active: "false" },
-      ]
+      ],
     } as any);
   });
-  
+
+  afterEach(() => {
+    // Clean up the temporary file after each test if it exists
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  });
+
   it("should read a CSV file and parse it", async () => {
     const result = await processCSV<TestRecord>(filePath);
-    
+
     expect(fs.readFileSync).toHaveBeenCalledWith(filePath, "utf-8");
     expect(Papa.parse).toHaveBeenCalled();
     expect(result).toHaveLength(2);
   });
-  
+
   it("should use Papa.parse with correct options", async () => {
     await processCSV(filePath);
-    
+
     expect(Papa.parse).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -48,66 +59,64 @@ describe("processCSV", () => {
         dynamicTyping: true,
         skipEmptyLines: true,
         transform: expect.any(Function),
-      })
+      }),
     );
   });
-  
+
   it("should apply custom field transformations when provided", async () => {
     const mockParseResult = {
-      data: [
-        { name: " John Doe ", age: "25" },
-      ]
+      data: [{ name: " John Doe ", age: "25" }],
     };
-    
+
     vi.mocked(Papa.parse).mockImplementationOnce((content, options) => {
       // Call the transform function to test it
       const nameTransformed = options.transform(" John Doe ", "name");
       const ageTransformed = options.transform("25", "age");
-      
+
       // Return mock data
       return mockParseResult as any;
     });
-    
+
     const customFields = {
       name: (value: string) => value.toUpperCase().trim(),
-      age: (value: string) => parseInt(value) + 5,
+      age: (value: string) => Number.parseInt(value) + 5,
     };
-    
+
     await processCSV(filePath, { fields: customFields });
-    
+
     // Check that Papa.parse was called with the expected options
     expect(Papa.parse).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
         transform: expect.any(Function),
-      })
+      }),
     );
   });
-  
+
   it("should handle file read errors", async () => {
     const errorMsg = "File not found";
     vi.mocked(fs.readFileSync).mockImplementationOnce(() => {
       throw new Error(errorMsg);
     });
-    
+
     await expect(processCSV(filePath)).rejects.toThrow(errorMsg);
   });
-  
+
   it("should handle parsing errors", async () => {
     vi.mocked(Papa.parse).mockImplementationOnce(() => {
       throw new Error("Parse error");
     });
-    
+
     await expect(processCSV(filePath)).rejects.toThrow("Parse error");
   });
-  
+
   it("should return an empty array if no records are found", async () => {
     vi.mocked(Papa.parse).mockReturnValueOnce({
-      data: []
+      data: [],
     } as any);
-    
+
     const result = await processCSV(filePath);
-    
+
     expect(result).toHaveLength(0);
   });
 });

--- a/apps/updater/src/utils/__tests__/processCSV.test.ts
+++ b/apps/updater/src/utils/__tests__/processCSV.test.ts
@@ -1,0 +1,113 @@
+import { processCSV } from "@updater/utils/processCSV";
+import fs from "node:fs";
+import Papa from "papaparse";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Simple mocks
+vi.mock("node:fs");
+vi.mock("papaparse");
+
+interface TestRecord {
+  name: string;
+  age: number;
+  active: boolean;
+}
+
+describe("processCSV", () => {
+  const filePath = "/tmp/test.csv";
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Set up mock implementations for each test
+    vi.mocked(fs.readFileSync).mockReturnValue("mock csv content" as any);
+    
+    vi.mocked(Papa.parse).mockReturnValue({
+      data: [
+        { name: " John Doe ", age: "25", active: "true" },
+        { name: " Jane Smith ", age: "30", active: "false" },
+      ]
+    } as any);
+  });
+  
+  it("should read a CSV file and parse it", async () => {
+    const result = await processCSV<TestRecord>(filePath);
+    
+    expect(fs.readFileSync).toHaveBeenCalledWith(filePath, "utf-8");
+    expect(Papa.parse).toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+  });
+  
+  it("should use Papa.parse with correct options", async () => {
+    await processCSV(filePath);
+    
+    expect(Papa.parse).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        header: true,
+        dynamicTyping: true,
+        skipEmptyLines: true,
+        transform: expect.any(Function),
+      })
+    );
+  });
+  
+  it("should apply custom field transformations when provided", async () => {
+    const mockParseResult = {
+      data: [
+        { name: " John Doe ", age: "25" },
+      ]
+    };
+    
+    vi.mocked(Papa.parse).mockImplementationOnce((content, options) => {
+      // Call the transform function to test it
+      const nameTransformed = options.transform(" John Doe ", "name");
+      const ageTransformed = options.transform("25", "age");
+      
+      // Return mock data
+      return mockParseResult as any;
+    });
+    
+    const customFields = {
+      name: (value: string) => value.toUpperCase().trim(),
+      age: (value: string) => parseInt(value) + 5,
+    };
+    
+    await processCSV(filePath, { fields: customFields });
+    
+    // Check that Papa.parse was called with the expected options
+    expect(Papa.parse).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        transform: expect.any(Function),
+      })
+    );
+  });
+  
+  it("should handle file read errors", async () => {
+    const errorMsg = "File not found";
+    vi.mocked(fs.readFileSync).mockImplementationOnce(() => {
+      throw new Error(errorMsg);
+    });
+    
+    await expect(processCSV(filePath)).rejects.toThrow(errorMsg);
+  });
+  
+  it("should handle parsing errors", async () => {
+    vi.mocked(Papa.parse).mockImplementationOnce(() => {
+      throw new Error("Parse error");
+    });
+    
+    await expect(processCSV(filePath)).rejects.toThrow("Parse error");
+  });
+  
+  it("should return an empty array if no records are found", async () => {
+    vi.mocked(Papa.parse).mockReturnValueOnce({
+      data: []
+    } as any);
+    
+    const result = await processCSV(filePath);
+    
+    expect(result).toHaveLength(0);
+  });
+});

--- a/apps/updater/src/utils/__tests__/redisCache.test.ts
+++ b/apps/updater/src/utils/__tests__/redisCache.test.ts
@@ -1,0 +1,86 @@
+import redis from "@updater/config/redis";
+import { cacheChecksum, getCachedChecksum } from "@updater/utils/redisCache";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock redis
+vi.mock("@updater/config/redis", () => ({
+  default: {
+    set: vi.fn().mockResolvedValue(true),
+    get: vi.fn().mockResolvedValue("abc123def456"),
+  },
+}));
+
+describe("redisCache", () => {
+  const fileName = "test-file.csv";
+  const checksum = "abc123def456";
+  
+  beforeEach(() => {
+    vi.resetAllMocks();
+    
+    // Default mock implementations
+    vi.mocked(redis.set).mockResolvedValue(true);
+    vi.mocked(redis.get).mockResolvedValue(checksum);
+  });
+  
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+  
+  describe("cacheChecksum", () => {
+    it("should store a checksum in Redis", async () => {
+      const result = await cacheChecksum(fileName, checksum);
+      
+      expect(redis.set).toHaveBeenCalledWith(`checksum:${fileName}`, checksum);
+      expect(result).toBe(true);
+    });
+    
+    it("should handle Redis errors gracefully", async () => {
+      // Setup the mock to throw an error
+      vi.mocked(redis.set).mockImplementation(() => {
+        throw new Error("Redis connection error");
+      });
+      
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      
+      const result = await cacheChecksum(fileName, checksum);
+      
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(result).toBeNull();
+      
+      consoleSpy.mockRestore();
+    });
+  });
+  
+  describe("getCachedChecksum", () => {
+    it("should retrieve a checksum from Redis", async () => {
+      const result = await getCachedChecksum(fileName);
+      
+      expect(redis.get).toHaveBeenCalledWith(`checksum:${fileName}`);
+      expect(result).toBe(checksum);
+    });
+    
+    it("should return null when the checksum is not found", async () => {
+      vi.mocked(redis.get).mockResolvedValueOnce(null);
+      
+      const result = await getCachedChecksum(fileName);
+      
+      expect(result).toBeNull();
+    });
+    
+    it("should handle Redis errors gracefully", async () => {
+      // Setup the mock to throw an error
+      vi.mocked(redis.get).mockImplementation(() => {
+        throw new Error("Redis connection error");
+      });
+      
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      
+      const result = await getCachedChecksum(fileName);
+      
+      expect(consoleSpy).toHaveBeenCalled();
+      expect(result).toBeNull();
+      
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added unit tests for previously uncovered API lib functions: getCarsByFuelType, getLatestMonth, and getUniqueMonths
- Added unit tests for previously uncovered updater utilities: downloadFile, processCSV, redisCache, and createUpdateTask
- Improved overall test coverage and reliability

## Test plan
- All test suites now pass with `pnpm test`
- Unit tests provide good coverage of edge cases and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)