### PR TITLE
Update resharePost message to optional

### DIFF
--- a/.changeset/chilly-tires-thank.md
+++ b/.changeset/chilly-tires-thank.md
@@ -1,0 +1,5 @@
+---
+"@sgcarstrends/updater": patch
+---
+
+Update reshare of page post to personal account without commentary on LinkedIn

--- a/apps/updater/src/lib/linkedin/post-to-linkedin.ts
+++ b/apps/updater/src/lib/linkedin/post-to-linkedin.ts
@@ -46,7 +46,7 @@ export const postToLinkedin = async ({
     console.log({ createdEntityId });
 
     if (createdEntityId) {
-      await resharePost({ createdEntityId, message });
+      await resharePost({ createdEntityId });
     }
 
     return createdEntityId;

--- a/apps/updater/src/lib/linkedin/reshare-post.ts
+++ b/apps/updater/src/lib/linkedin/reshare-post.ts
@@ -14,7 +14,7 @@ export const resharePost = async ({
       },
       body: JSON.stringify({
         author: `urn:li:person:${Resource.LINKEDIN_USER_ID.value}`,
-        commentary: message,
+        commentary: message ?? "",
         visibility: "PUBLIC",
         distribution: {
           feedDistribution: "MAIN_FEED",

--- a/apps/updater/src/types/social-media.ts
+++ b/apps/updater/src/types/social-media.ts
@@ -22,5 +22,5 @@ export interface PostToTwitterParam extends PostToSocialMediaParam {}
 
 export type ResharePostParam = {
   createdEntityId: CreatedEntityId;
-  message: string;
+  message?: string;
 };


### PR DESCRIPTION
This is to simulate LinkedIn's "Click Repost to share the post immediately without additional text." feature
