### PR TITLE
Add compare metrics endpoint for cars

### DIFF
--- a/.changeset/free-dodos-sing.md
+++ b/.changeset/free-dodos-sing.md
@@ -1,0 +1,5 @@
+---
+"@sgcarstrends/api": minor
+---
+
+Add compare metrics endpoint for cars

--- a/apps/api/src/config/db.ts
+++ b/apps/api/src/config/db.ts
@@ -1,5 +1,6 @@
 import { CACHE_TTL } from "@api/config";
 import { neon } from "@neondatabase/serverless";
+import * as schema from "@sgcarstrends/schema";
 import { upstashCache } from "drizzle-orm/cache/upstash";
 import { drizzle } from "drizzle-orm/neon-http";
 import { Resource } from "sst";
@@ -12,6 +13,7 @@ export const db = drizzle(sql, {
     global: true,
     config: { ex: CACHE_TTL },
   }),
+  schema,
 });
 
 export default db;

--- a/apps/api/src/queries/cars.ts
+++ b/apps/api/src/queries/cars.ts
@@ -1,0 +1,31 @@
+import db from "@api/config/db";
+import { cars } from "@sgcarstrends/schema";
+import { eq } from "drizzle-orm";
+
+export const getCarsByMonth = (month: string) =>
+  db.query.cars.findMany({
+    where: eq(cars.month, month),
+    columns: {
+      number: true,
+      fuel_type: true,
+      vehicle_type: true,
+    },
+  });
+
+export const getCarMetricsData = async (
+  currentPeriod: string,
+  previousMonthPeriod: string,
+  previousYearPeriod: string,
+) => {
+  const [currentData, previousMonthData, previousYearData] = await Promise.all([
+    getCarsByMonth(currentPeriod),
+    getCarsByMonth(previousMonthPeriod),
+    getCarsByMonth(previousYearPeriod),
+  ]);
+
+  return {
+    currentData,
+    previousMonthData,
+    previousYearData,
+  };
+};

--- a/apps/api/src/queries/cars.ts
+++ b/apps/api/src/queries/cars.ts
@@ -12,20 +12,3 @@ export const getCarsByMonth = (month: string) =>
     },
   });
 
-export const getCarMetricsData = async (
-  currentPeriod: string,
-  previousMonthPeriod: string,
-  previousYearPeriod: string,
-) => {
-  const [currentData, previousMonthData, previousYearData] = await Promise.all([
-    getCarsByMonth(currentPeriod),
-    getCarsByMonth(previousMonthPeriod),
-    getCarsByMonth(previousYearPeriod),
-  ]);
-
-  return {
-    currentData,
-    previousMonthData,
-    previousYearData,
-  };
-};

--- a/apps/api/src/queries/index.ts
+++ b/apps/api/src/queries/index.ts
@@ -1,0 +1,1 @@
+export * from "./cars";

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -4,12 +4,9 @@ export const CarsRegistrationQuerySchema = z
   .object({ month: z.string() })
   .strict();
 
-export const ComparisonQuerySchema = z
-  .object({
-    month: z.string(),
-    type: z.optional(z.enum(["yearly", "monthly"])),
-  })
-  .strict();
+export const ComparisonQuerySchema = z.object({
+  month: z.string(),
+});
 
 // Common schemas
 export const MonthSchema = z.string().regex(/^\d{4}-\d{2}$/); // YYYY-MM format

--- a/apps/api/src/v1/service/car.service.ts
+++ b/apps/api/src/v1/service/car.service.ts
@@ -1,7 +1,7 @@
 import { HYBRID_REGEX, MPV_REGEX } from "@api/config";
 import db from "@api/config/db";
 import { getLatestMonth } from "@api/lib/getLatestMonth";
-import { getCarMetricsData } from "@api/queries";
+import { getCarsByMonth } from "@api/queries";
 import { cars } from "@sgcarstrends/schema";
 import { getTrailingSixMonths } from "@sgcarstrends/utils";
 import { type SQL, and, between, desc, eq, ilike, sql } from "drizzle-orm";
@@ -69,6 +69,24 @@ export const fetchCars = (filters: SQL<unknown>[]) =>
     .from(cars)
     .where(and(...filters))
     .orderBy(desc(cars.month));
+
+const getCarMetricsData = async (
+  currentPeriod: string,
+  previousMonthPeriod: string,
+  previousYearPeriod: string,
+) => {
+  const [currentData, previousMonthData, previousYearData] = await Promise.all([
+    getCarsByMonth(currentPeriod),
+    getCarsByMonth(previousMonthPeriod),
+    getCarsByMonth(previousYearPeriod),
+  ]);
+
+  return {
+    currentData,
+    previousMonthData,
+    previousYearData,
+  };
+};
 
 export const getCarMetricsForPeriod = async (
   currentPeriod: string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new endpoint for comparing car metrics, allowing users to view total counts and breakdowns by fuel and vehicle type for selected periods.
- **Improvements**
	- Simplified the comparison data structure, providing clearer and more concise period-based metrics without detailed change calculations.
- **Bug Fixes**
	- None.
- **Documentation**
	- Added release notes for the new comparison endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->