### PR TITLE
Add API endpoint to get top fuel and vehicle types for a given month

### DIFF
--- a/.changeset/poor-things-taste.md
+++ b/.changeset/poor-things-taste.md
@@ -1,0 +1,5 @@
+---
+"@sgcarstrends/api": minor
+---
+
+Add API endpoint to get the top fuel and vehicle types for a month

--- a/apps/api/src/queries/cars.ts
+++ b/apps/api/src/queries/cars.ts
@@ -1,6 +1,6 @@
 import db from "@api/config/db";
 import { cars } from "@sgcarstrends/schema";
-import { eq } from "drizzle-orm";
+import { desc, eq, sql, sum } from "drizzle-orm";
 
 export const getCarsByMonth = (month: string) =>
   db.query.cars.findMany({
@@ -12,3 +12,26 @@ export const getCarsByMonth = (month: string) =>
     },
   });
 
+export const getTopTypes = (month: string) =>
+  db.batch([
+    db
+      .select({
+        name: cars.fuel_type,
+        total: sql<number>`cast(sum(${cars.number}) as integer)`,
+      })
+      .from(cars)
+      .where(eq(cars.month, month))
+      .groupBy(cars.fuel_type)
+      .orderBy(desc(sum(cars.number)))
+      .limit(1),
+    db
+      .select({
+        name: cars.vehicle_type,
+        total: sql<number>`cast(sum(${cars.number}) as integer)`,
+      })
+      .from(cars)
+      .where(eq(cars.month, month))
+      .groupBy(cars.vehicle_type)
+      .orderBy(desc(sum(cars.number)))
+      .limit(1),
+  ]);

--- a/apps/api/src/schemas/index.ts
+++ b/apps/api/src/schemas/index.ts
@@ -4,6 +4,32 @@ export const CarsRegistrationQuerySchema = z
   .object({ month: z.string() })
   .strict();
 
+export const TopTypesQuerySchema = z
+  .object({
+    month: z.string().openapi({
+      description: "Month in YYYY-MM format to get top types for",
+      example: "2025-01",
+    }),
+  })
+  .openapi({
+    description: "Query parameters for top fuel and vehicle types endpoint",
+  });
+
+export const TopTypeSchema = z
+  .object({
+    name: z.string(),
+    total: z.number(),
+  })
+  .nullable();
+
+export const TopTypesResponseSchema = z.object({
+  data: z.object({
+    month: z.string(),
+    topFuelType: TopTypeSchema,
+    topVehicleType: TopTypeSchema,
+  }),
+});
+
 export const ComparisonQuerySchema = z
   .object({
     month: z.string().openapi({
@@ -124,6 +150,7 @@ export const LatestMonthResponseSchema = z
 export const MonthsByYearSchema = z.record(z.string(), z.array(z.string()));
 
 export type ComparisonQuery = z.infer<typeof ComparisonQuerySchema>;
+export type TopTypesQuery = z.infer<typeof TopTypesQuerySchema>;
 export type MakeParams = z.infer<typeof MakeParamSchema>;
 export type MakeQuery = z.infer<typeof MakeQuerySchema>;
 export type CarQuery = z.infer<typeof CarQuerySchema>;

--- a/apps/api/src/v1/routes/cars.ts
+++ b/apps/api/src/v1/routes/cars.ts
@@ -93,7 +93,7 @@ app.openapi(
     summary: "Compare car registration metrics",
     description:
       "Get car registration metrics for a specific month compared to previous month and same month in previous year",
-    // tags: ["Cars"],
+    tags: ["Cars"],
     request: { query: ComparisonQuerySchema },
     responses: {
       200: {
@@ -129,6 +129,7 @@ app.openapi(
     summary: "Top fuel and vehicle type by month",
     description:
       "Get the most popular fuel type and vehicle type based on registration numbers for a specific month",
+    tags: ["Cars"],
     request: { query: TopTypesQuerySchema },
     responses: {
       200: {


### PR DESCRIPTION
- **Add API endpoint for the top fuel and vehicle type by month**
- **Add tags to routes**
- **Add changelog**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve the top fuel type and vehicle type for a specified month.
  - The endpoint provides details on the most popular fuel and vehicle types, including their names and totals, for the selected month.
  - Enhanced API documentation to include the new endpoint and its request/response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->