### PR TITLE
Add endpoints for fuel and vehicle types by month

### DIFF
--- a/.changeset/wild-yaks-dress.md
+++ b/.changeset/wild-yaks-dress.md
@@ -1,0 +1,5 @@
+---
+"@sgcarstrends/api": minor
+---
+
+Add endpoints for fuel and vehicle types by month

--- a/apps/api/src/queries/cars.ts
+++ b/apps/api/src/queries/cars.ts
@@ -108,6 +108,92 @@ export const getTopTypes = (month: string) =>
       .limit(1),
   ]);
 
+export const getDistinctFuelTypes = (month: string) => {
+  const whereConditions = [];
+
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  return db
+    .selectDistinct({ fuelType: cars.fuel_type })
+    .from(cars)
+    .where(and(...whereConditions))
+    .orderBy(asc(cars.fuel_type));
+};
+
+export const getFuelTypeByMonth = (fuelType: string, month: string) => {
+  const whereConditions = [
+    ilike(cars.fuel_type, fuelType.replaceAll("-", "%")),
+  ];
+
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  return db.batch([
+    db
+      .select({ total: sql<number>`cast(sum(${cars.number}) as integer)` })
+      .from(cars)
+      .where(and(...whereConditions)),
+    db
+      .select({
+        month: cars.month,
+        make: cars.make,
+        fuel_type: cars.fuel_type,
+        count: sql<number>`cast(sum(${cars.number}) as integer)`,
+      })
+      .from(cars)
+      .where(and(...whereConditions))
+      .groupBy(cars.month, cars.make, cars.fuel_type)
+      .orderBy(desc(sum(cars.number)))
+      .having(gt(sum(cars.number), 0)),
+  ]);
+};
+
+export const getDistinctVehicleTypes = (month: string) => {
+  const whereConditions = [];
+
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  return db
+    .selectDistinct({ vehicleType: cars.vehicle_type })
+    .from(cars)
+    .where(and(...whereConditions))
+    .orderBy(asc(cars.vehicle_type));
+};
+
+export const getVehicleTypeByMonth = (vehicleType: string, month: string) => {
+  const whereConditions = [
+    ilike(cars.vehicle_type, vehicleType.replaceAll("-", "%")),
+  ];
+
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  return db.batch([
+    db
+      .select({ total: sql<number>`cast(sum(${cars.number}) as integer)` })
+      .from(cars)
+      .where(and(...whereConditions)),
+    db
+      .select({
+        month: cars.month,
+        make: cars.make,
+        vehicle_type: cars.vehicle_type,
+        count: sql<number>`cast(sum(${cars.number}) as integer)`,
+      })
+      .from(cars)
+      .where(and(...whereConditions))
+      .groupBy(cars.month, cars.make, cars.vehicle_type)
+      .orderBy(desc(sum(cars.number)))
+      .having(gt(sum(cars.number), 0)),
+  ]);
+};
+
 export const getDistinctMakes = () =>
   db.selectDistinct({ make: cars.make }).from(cars).orderBy(asc(cars.make));
 

--- a/apps/api/src/v1/routes/cars.ts
+++ b/apps/api/src/v1/routes/cars.ts
@@ -6,9 +6,13 @@ import {
   getCarsByFuelType,
   getCarsByVehicleType,
   getCarsTopMakesByFuelType,
+  getDistinctFuelTypes,
   getDistinctMakes,
+  getDistinctVehicleTypes,
+  getFuelTypeByMonth,
   getMake,
   getTopTypes,
+  getVehicleTypeByMonth,
 } from "@api/queries/cars";
 import {
   CarQuerySchema,
@@ -20,6 +24,7 @@ import {
   MakeQuerySchema,
   MakeResponseSchema,
   MakesResponseSchema,
+  MonthSchema,
   MonthsQuerySchema,
   TopMakesQuerySchema,
   TopMakesResponseSchema,
@@ -83,6 +88,40 @@ app.openapi(
     }
   },
 );
+
+app.get("/fuel-types", async (c) => {
+  const { month } = c.req.query();
+
+  const result = await getDistinctFuelTypes(month);
+  const fuelTypes = result.map(({ fuelType }) => fuelType);
+  return c.json({ data: fuelTypes });
+});
+
+app.get("/fuel-types/:fuelType", async (c) => {
+  const { fuelType } = c.req.param();
+  const { month } = c.req.query();
+
+  const [totalResult, result] = await getFuelTypeByMonth(fuelType, month);
+
+  return c.json({ total: totalResult[0].total, data: result });
+});
+
+app.get("/vehicle-types", async (c) => {
+  const { month } = c.req.query();
+
+  const result = await getDistinctVehicleTypes(month);
+  const vehicleTypes = result.map(({ vehicleType }) => vehicleType);
+  return c.json({ data: vehicleTypes });
+});
+
+app.get("/vehicle-types/:vehicleType", async (c) => {
+  const { vehicleType } = c.req.param();
+  const { month } = c.req.query();
+
+  const [totalResult, result] = await getVehicleTypeByMonth(vehicleType, month);
+
+  return c.json({ total: totalResult[0].total, data: result });
+});
 
 app.openapi(
   createRoute({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new API endpoints to retrieve lists of fuel types and vehicle types, optionally filtered by month.
  - Added endpoints to provide detailed and aggregated data for a specific fuel type or vehicle type by month.
  - Users can now access both distinct values and breakdowns for fuel and vehicle types via the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->