### PR TITLE
feat: add generic banner component with page-specific content support

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,3 @@
-import classNames from "classnames";
-import { Inter } from "next/font/google";
-import Script from "next/script";
-import { NuqsAdapter } from "nuqs/adapters/next/app";
-import type { ReactNode } from "react";
 import LoadingIndicator from "@web/app/loading-indicator";
 import { Providers } from "@web/app/providers";
 import { Analytics } from "@web/components/analytics";
@@ -11,7 +6,13 @@ import { Footer } from "@web/components/footer";
 import { Header } from "@web/components/header";
 import { NotificationPrompt } from "@web/components/notification-prompt";
 import { ANNOUNCEMENT, SITE_TITLE, SITE_URL } from "@web/config";
+import classNames from "classnames";
+import { Inter } from "next/font/google";
+import Script from "next/script";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
+import type { ReactNode } from "react";
 import "./globals.css";
+import { Banner } from "@web/components/banner";
 import type { Metadata } from "next";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -57,6 +58,7 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
           <NuqsAdapter>
             <LoadingIndicator />
             <Header />
+            <Banner />
             <main className="container mx-auto px-6 py-8">{children}</main>
             <Footer />
           </NuqsAdapter>

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -1,5 +1,8 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import {
+  type BannerAction,
+  type BannerState,
+  createBannerSlice,
+} from "@web/app/store/banner-slice";
 import {
   type COEAction,
   type COEState,
@@ -15,9 +18,11 @@ import {
   type NotificationAction,
   type NotificationState,
 } from "@web/app/store/notification-slice";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
-type State = DateState & COEState & NotificationState;
-type Action = DateAction & COEAction & NotificationAction;
+type State = DateState & COEState & NotificationState & BannerState;
+type Action = DateAction & COEAction & NotificationAction & BannerAction;
 
 const useStore = create<State & Action, [["zustand/persist", unknown]]>(
   persist(
@@ -25,6 +30,7 @@ const useStore = create<State & Action, [["zustand/persist", unknown]]>(
       ...createDateSlice(...a),
       ...createCoeSlice(...a),
       ...createNotificationSlice(...a),
+      ...createBannerSlice(...a),
     }),
     {
       name: "config",

--- a/apps/web/src/app/store/banner-slice.ts
+++ b/apps/web/src/app/store/banner-slice.ts
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import type { StateCreator } from "zustand";
+
+export type BannerState = {
+  bannerContent: ReactNode | null;
+};
+
+export type BannerAction = {
+  setBannerContent: (content: ReactNode | null) => void;
+};
+
+export const createBannerSlice: StateCreator<BannerState & BannerAction> = (
+  set,
+) => ({
+  bannerContent: null,
+  setBannerContent: (bannerContent) => set({ bannerContent }),
+});

--- a/apps/web/src/components/banner.tsx
+++ b/apps/web/src/components/banner.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import useStore from "@web/app/store";
+
+export const Banner = () => {
+  const { bannerContent } = useStore();
+
+  if (!bannerContent) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center justify-center border-b bg-gray-50">
+      <div className="container mx-auto px-6 py-4">{bannerContent}</div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Implemented a generic Banner component that can display dynamic content based on page context
- Added Zustand store slice for managing banner state across the application
- Integrated banner into root layout for site-wide availability