### PR TITLE
feat(api): implement blog post idempotency

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -55,7 +55,8 @@ bidding results. Key features include:
 - **src/v1/**: Versioned API routes (cars, coe, months) with bearer authentication
 - **src/routes/**: Workflow endpoints and social media webhooks
 - **src/trpc/**: Type-safe tRPC router with context creation
-- **src/lib/workflows/**: QStash workflow implementations for data processing
+- **src/lib/workflows/**: QStash workflows (cars, coe, posts, save-post, update-cars, update-coe, workflow, options)
+- **src/lib/gemini/**: LLM-powered blog post generation using Google Gemini AI
 - **src/lib/social/**: Platform-specific social media posting logic
 - **src/config/**: Configuration for databases, Redis, QStash, and platforms
 - **src/utils/**: Utility functions for file processing, caching, and responses
@@ -64,9 +65,11 @@ bidding results. Key features include:
 
 The API uses a workflow-based system for data processing:
 
-- **Task Processing** (`src/lib/workflows/workflow.ts`): Common workflow patterns with Redis timestamps
-- **Data Workflows** (`src/lib/workflows/cars.ts`, `src/lib/workflows/coe.ts`): Automated data fetching and processing
-- **Blog Generation** (`src/lib/workflows/posts.ts`): LLM-powered blog post creation using Google Gemini
+- **Workflow Runtime** (`src/lib/workflows/workflow.ts`): Common workflow helpers, step runner, Redis timestamps
+- **Data Updaters** (`src/lib/workflows/update-cars.ts`, `src/lib/workflows/update-coe.ts`): Automated data fetching and processing
+- **Blog Generation** (`src/lib/workflows/posts.ts`): LLM-powered blog post creation using Google Gemini via `src/lib/gemini/generate-post.ts`
+- **Post Management** (`src/lib/workflows/save-post.ts`): Blog post persistence with idempotency support
+- **Main Workflows** (`src/lib/workflows/cars.ts`, `src/lib/workflows/coe.ts`): Main workflow orchestrators exposed as routes
 - **Social Publishing**: Automated posting to platforms when data updates occur
 
 ### Authentication & Security

--- a/apps/api/src/lib/gemini/config.ts
+++ b/apps/api/src/lib/gemini/config.ts
@@ -1,18 +1,18 @@
-import type { GenerateContentResponse } from "@google/genai";
+import type { GenerateContentConfig } from "@google/genai";
+
+export const GEMINI_MODEL = "gemini-2.5-flash";
+
+export const GEMINI_CONFIG: GenerateContentConfig = {
+  thinkingConfig: {
+    thinkingBudget: -1,
+  },
+  responseMimeType: "text/plain",
+};
 
 export interface BlogGenerationParams {
   data: string[];
   month: string;
   dataType: "cars" | "coe";
-}
-
-export interface BlogPost {
-  title: string;
-  content: string;
-  metadata: Partial<GenerateContentResponse> & {
-    month: string;
-    dataType: string;
-  };
 }
 
 export interface BlogResult {
@@ -22,15 +22,6 @@ export interface BlogResult {
   title: string;
   slug: string;
 }
-
-export const GEMINI_MODEL = "gemini-2.5-flash";
-
-export const GEMINI_CONFIG = {
-  thinkingConfig: {
-    thinkingBudget: -1,
-  },
-  responseMimeType: "text/plain",
-};
 
 export const SYSTEM_INSTRUCTIONS = {
   cars: `You are a data analyst specialising in Singapore's car market.

--- a/apps/api/src/lib/workflows/save-post.ts
+++ b/apps/api/src/lib/workflows/save-post.ts
@@ -1,7 +1,7 @@
 import type { GenerateContentResponse } from "@google/genai";
 import { db, posts } from "@sgcarstrends/database";
 import slugify from "@sindresorhus/slugify";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 export interface BlogPost {
   title: string;
@@ -14,18 +14,23 @@ export interface BlogPost {
 
 export const savePost = async (data: BlogPost) => {
   const slug = slugify(data.title);
+  const { month, dataType } = data.metadata;
 
+  // Check for existing post with same month + category combination
   const [existingPost] = await db
     .select()
     .from(posts)
-    .where(eq(posts.slug, slug))
+    .where(and(eq(posts.month, month), eq(posts.dataType, dataType)))
     .limit(1);
 
   if (existingPost) {
-    console.log(`Blog post with slug "${slug}" already exists, skipping save`);
+    console.log(
+      `[BLOG_SAVE] Post for ${dataType} ${month} already exists (id: ${existingPost.id}), skipping save`,
+    );
     return existingPost;
   }
 
+  // Use INSERT with ON CONFLICT DO NOTHING for atomic operation
   const [newPost] = await db
     .insert(posts)
     .values({
@@ -34,10 +39,31 @@ export const savePost = async (data: BlogPost) => {
       content: data.content,
       metadata: data.metadata,
       publishedAt: new Date(),
+      month,
+      dataType,
+    })
+    .onConflictDoNothing({
+      target: [posts.month, posts.dataType],
     })
     .returning();
 
-  console.log(`Blog post saved with ID: ${newPost.id}, slug: ${newPost.slug}`);
+  // If insert was skipped due to conflict, fetch existing post
+  if (!newPost) {
+    const [conflictedPost] = await db
+      .select()
+      .from(posts)
+      .where(and(eq(posts.month, month), eq(posts.dataType, dataType)))
+      .limit(1);
+
+    console.log(
+      `[BLOG_SAVE] Post for ${dataType} ${month} was created by another process (id: ${conflictedPost?.id})`,
+    );
+    return conflictedPost;
+  }
+
+  console.log(
+    `[BLOG_SAVE] Post saved successfully - id: ${newPost.id}, slug: ${newPost.slug}, month: ${month}, category: ${dataType}`,
+  );
 
   return newPost;
 };

--- a/apps/api/src/lib/workflows/workflow.ts
+++ b/apps/api/src/lib/workflows/workflow.ts
@@ -4,7 +4,7 @@ import type { UpdaterResult } from "@api/lib/updater";
 import { redis } from "@sgcarstrends/utils";
 import type { WorkflowContext } from "@upstash/workflow";
 
-export interface Task {
+export interface WorkflowStep {
   name: string;
   handler: () => Promise<UpdaterResult>;
 }

--- a/packages/database/migrations/0004_blue_barracuda.sql
+++ b/packages/database/migrations/0004_blue_barracuda.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "posts"
+    ADD COLUMN "month" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "posts"
+    ADD COLUMN "data_type" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "posts"
+    ADD CONSTRAINT "posts_month_dataType_unique" UNIQUE ("month", "data_type");

--- a/packages/database/migrations/meta/0004_snapshot.json
+++ b/packages/database/migrations/meta/0004_snapshot.json
@@ -1,0 +1,606 @@
+{
+  "id": "13ce762e-58c4-4a41-b9eb-ee4c565f28f3",
+  "prevId": "dd00b7c0-4872-4aca-b338-e1a0d68744ca",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analytics": {
+      "name": "analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "pathname": {
+          "name": "pathname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrer": {
+          "name": "referrer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag": {
+          "name": "flag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cars": {
+      "name": "cars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "importer_type": {
+          "name": "importer_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fuel_type": {
+          "name": "fuel_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vehicle_type": {
+          "name": "vehicle_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "month_make_idx": {
+          "name": "month_make_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "make",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "month_idx": {
+          "name": "month_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "make_idx": {
+          "name": "make_idx",
+          "columns": [
+            {
+              "expression": "make",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fuel_type_idx": {
+          "name": "fuel_type_idx",
+          "columns": [
+            {
+              "expression": "fuel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "make_fuel_type_idx": {
+          "name": "make_fuel_type_idx",
+          "columns": [
+            {
+              "expression": "make",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fuel_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "number_idx": {
+          "name": "number_idx",
+          "columns": [
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coe": {
+      "name": "coe",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bidding_no": {
+          "name": "bidding_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quota": {
+          "name": "quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bids_success": {
+          "name": "bids_success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bids_received": {
+          "name": "bids_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "premium": {
+          "name": "premium",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "month_vehicle_idx": {
+          "name": "month_vehicle_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicle_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vehicle_class_idx": {
+          "name": "vehicle_class_idx",
+          "columns": [
+            {
+              "expression": "vehicle_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "month_bidding_no_idx": {
+          "name": "month_bidding_no_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bidding_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premium_idx": {
+          "name": "premium_idx",
+          "columns": [
+            {
+              "expression": "premium",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bids_idx": {
+          "name": "bids_idx",
+          "columns": [
+            {
+              "expression": "bids_success",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bids_received",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "month_bidding_no_vehicle_class_idx": {
+          "name": "month_bidding_no_vehicle_class_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "bidding_no",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicle_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coe_pqp": {
+      "name": "coe_pqp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vehicle_class": {
+          "name": "vehicle_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pqp": {
+          "name": "pqp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pqp_month_vehicle_class_idx": {
+          "name": "pqp_month_vehicle_class_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vehicle_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pqp_vehicle_class_idx": {
+          "name": "pqp_vehicle_class_idx",
+          "columns": [
+            {
+              "expression": "vehicle_class",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pqp_idx": {
+          "name": "pqp_idx",
+          "columns": [
+            {
+              "expression": "pqp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "modified_at": {
+          "name": "modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        },
+        "posts_month_dataType_unique": {
+          "name": "posts_month_dataType_unique",
+          "nullsNotDistinct": false,
+          "columns": ["month", "data_type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1754754621004,
       "tag": "0003_dazzling_wendell_vaughn",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1757798411721,
+      "tag": "0004_blue_barracuda",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/posts.ts
+++ b/packages/database/src/schema/posts.ts
@@ -1,15 +1,31 @@
-import { jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import {
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from "drizzle-orm/pg-core";
 
-export const posts = pgTable("posts", {
-  id: uuid("id").primaryKey().defaultRandom(),
-  title: text("title").notNull(),
-  slug: text("slug").notNull().unique(),
-  content: text("content").notNull(),
-  metadata: jsonb("metadata"),
-  publishedAt: timestamp("published_at"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  modifiedAt: timestamp("modified_at").defaultNow().notNull(),
-});
+export const posts = pgTable(
+  "posts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    title: text("title").notNull(),
+    slug: text("slug").notNull().unique(),
+    content: text("content").notNull(),
+    metadata: jsonb("metadata"),
+    month: text().notNull(),
+    dataType: text().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    modifiedAt: timestamp("modified_at").defaultNow().notNull(),
+    publishedAt: timestamp("published_at"),
+  },
+  (table) => ({
+    // Composite unique constraint to prevent duplicate posts for same month + dataType
+    uniqueMonthCategory: unique().on(table.month, table.dataType),
+  }),
+);
 
 export type InsertPost = typeof posts.$inferInsert;
 export type SelectPost = typeof posts.$inferSelect;


### PR DESCRIPTION
## Summary
• Add database-level unique constraint on month + data_type to prevent duplicate blog posts
• Implement atomic INSERT with ON CONFLICT DO NOTHING for race condition safety
• Enhanced logging and error handling for blog post persistence workflow